### PR TITLE
Update to make nvm install use new nvmrc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,12 +13,12 @@ RUN apt-get update \
 SHELL ["/bin/bash", "--login", "-c"]
 
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
-RUN nvm install lts/*
 
 # Caches `.npm` folder in the image, so future `npm install/ci` actions are faster for `gutenberg-mobile` project
 RUN git clone https://github.com/wordpress-mobile/gutenberg-mobile.git /var/gutenberg-mobile --depth 1 \
     && pushd /var/gutenberg-mobile \
     && git submodule update --init --recursive  \
+    && nvm install \
     && npm ci --no-audit --no-progress --unsafe-perm \
     && popd \
     && rm -rf /var/gutenberg-mobile

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update \
 SHELL ["/bin/bash", "--login", "-c"]
 
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
+RUN nvm install lts/*
 
 # Caches `.npm` folder in the image, so future `npm install/ci` actions are faster for `gutenberg-mobile` project
 RUN git clone https://github.com/wordpress-mobile/gutenberg-mobile.git /var/gutenberg-mobile --depth 1 \


### PR DESCRIPTION
After we added an `.nvmrc` file to Gutenberg Mobile to specify its node version (see https://github.com/wordpress-mobile/gutenberg-mobile/pull/4016), we can now use it here to make sure versions stay in sync in the future.