### PR TITLE
Install `php-cli` package for using WP-CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 RUN echo fs.inotify.max_user_watches=524288 | tee -a /etc/sysctl.conf
 
 RUN apt-get update \
-    && apt-get install -y curl git \
+    && apt-get install -y curl git php-cli \
     && apt-get -y autoclean
 
 SHELL ["/bin/bash", "--login", "-c"]


### PR DESCRIPTION
In an incoming PR from GB-mobile repository ([reference](https://github.com/wordpress-mobile/gutenberg-mobile/pull/4366/files#r772182898)), we're introducing changes that will require PHP CLI to be available in the Docker image, specifically when running the NPM command `prebundle:js` ([reference](https://github.com/wordpress-mobile/gutenberg-mobile/blob/313e99374c6204b3ec73c74981fbf7f9b152c92c/package.json#L67)) on the Buildkite job "Bundle Android" ([reference](https://github.com/wordpress-mobile/gutenberg-mobile/blob/313e99374c6204b3ec73c74981fbf7f9b152c92c/.buildkite/pipeline.yml#L12-L29)).

The main purpose of the command `prebundle:js` is to update the i18n localizations of the editor so they are included in the produced JS bundle. This command uses [WP-CLI](https://github.com/wp-cli/wp-cli) underneath, which requires PHP CLI, for this reason, this PR updates the Docker image and installs the `php-cli` package.

## How I test the changes
- Prevent the `gutenberg-mobile` folder to be deleted by disabling the following line: https://github.com/wordpress-mobile/docker-gb-mobile-image/blob/a6f5055ba2e41c619fce3d2fe57dfc3d27b124e6/Dockerfile#L25
- Build locally the Docker image by running `docker run -it gb-mobile`.
- Create a container with interactive mode by running `docker run -it gb-mobile`.
- Verify that WP-CLI can be invoked by running `cd var/gutenberg-mobile && npm run wp -- cli info` in the Docker interactive session.