### PR TITLE
Install extra PHP libraries required by i18n WP-CLI command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 RUN echo fs.inotify.max_user_watches=524288 | tee -a /etc/sysctl.conf
 
 RUN apt-get update \
-    && apt-get install -y curl git php-cli \
+    && apt-get install -y curl git php-cli php-mbstring  \
     && apt-get -y autoclean
 
 SHELL ["/bin/bash", "--login", "-c"]


### PR DESCRIPTION
Following up https://github.com/wordpress-mobile/docker-gb-mobile-image/pull/3, after testing the i18n WP-CLI command on changes introduced in https://github.com/wordpress-mobile/gutenberg-mobile/pull/4366, I noticed that one of the commands involved in the process required extra PHP libraries in order to extract the strings from source code.

**Extra PHP libraries added:**
- `php-mbstring`

## Test
I performed a full test using the generated Docker image with tag `6804aad7632be7db25870cdf283ed310f0c8380e`, and I verified that the image now contains all the required PHP libraries to run the command introduced in https://github.com/wordpress-mobile/gutenberg-mobile/pull/4366.